### PR TITLE
chore: release agent-burn v20.0.20

### DIFF
--- a/apps/agent-burn/package.json
+++ b/apps/agent-burn/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"description": "Compare local coding-agent usage against subscription limits and API-equivalent value",
 	"homepage": "https://github.com/Melvynx/agent-burn#readme",
 	"bugs": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agent-burn/docs",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"private": true,
 	"description": "Agent Burn website and documentation",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn-monorepo",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"private": true,
 	"workspaces": [
 		"apps/*",

--- a/packages/agent-burn-darwin-arm64/package.json
+++ b/packages/agent-burn-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn-darwin-arm64",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"description": "Native agent-burn binary for macOS arm64",
 	"license": "MIT",
 	"repository": {

--- a/packages/agent-burn-darwin-x64/package.json
+++ b/packages/agent-burn-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn-darwin-x64",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"description": "Native agent-burn binary for macOS x64",
 	"license": "MIT",
 	"repository": {

--- a/packages/agent-burn-linux-arm64/package.json
+++ b/packages/agent-burn-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn-linux-arm64",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"description": "Static native agent-burn binary for Linux arm64",
 	"license": "MIT",
 	"repository": {

--- a/packages/agent-burn-linux-x64/package.json
+++ b/packages/agent-burn-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn-linux-x64",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"description": "Static native agent-burn binary for Linux x64",
 	"license": "MIT",
 	"repository": {

--- a/packages/agent-burn-win32-arm64/package.json
+++ b/packages/agent-burn-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn-win32-arm64",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"description": "Native agent-burn binary for Windows arm64",
 	"license": "MIT",
 	"repository": {

--- a/packages/agent-burn-win32-x64/package.json
+++ b/packages/agent-burn-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-burn-win32-x64",
-	"version": "20.0.19",
+	"version": "20.0.20",
 	"description": "Native agent-burn binary for Windows x64",
 	"license": "MIT",
 	"repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-burn"
-version = "20.0.19"
+version = "20.0.20"
 dependencies = [
  "agent-burn-cli",
  "agent-burn-terminal",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agent-burn-cli"
-version = "20.0.19"
+version = "20.0.20"
 dependencies = [
  "insta",
  "serde_json",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agent-burn-terminal"
-version = "20.0.19"
+version = "20.0.20"
 dependencies = [
  "insta",
  "terminal_size",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "agent-burn-test-support"
-version = "20.0.19"
+version = "20.0.20"
 dependencies = [
  "assert_fs",
 ]

--- a/rust/crates/agent-burn-cli/Cargo.toml
+++ b/rust/crates/agent-burn-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-burn-cli"
-version = "20.0.19"
+version = "20.0.20"
 edition = "2024"
 build = "build.rs"
 

--- a/rust/crates/agent-burn-terminal/Cargo.toml
+++ b/rust/crates/agent-burn-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-burn-terminal"
-version = "20.0.19"
+version = "20.0.20"
 edition = "2024"
 
 [dependencies]

--- a/rust/crates/agent-burn-test-support/Cargo.toml
+++ b/rust/crates/agent-burn-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-burn-test-support"
-version = "20.0.19"
+version = "20.0.20"
 edition = "2024"
 publish = false
 

--- a/rust/crates/agent-burn/Cargo.toml
+++ b/rust/crates/agent-burn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-burn"
-version = "20.0.19"
+version = "20.0.20"
 edition = "2024"
 build = "build.rs"
 


### PR DESCRIPTION
Bumps the monorepo, native packages, and Rust workspace to agent-burn 20.0.20.

This patch release will use the tag-triggered workflow to publish all six native platform packages with provenance; the current 20.0.19 release only has the macOS ARM64 native package on npm.

Testing:
- cargo build --manifest-path rust/Cargo.toml --release --bin agent-burn
- pnpm --dir apps/agent-burn exec publint
- node --test apps/agent-burn/src/cli.test.ts nix/models-dev-compact.test.ts
- release binary version, help, summary JSON, and legacy-command smoke tests

> This text was generated by Codex using GPT-5.
